### PR TITLE
Fix the Format accessor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- The ``Format`` accessor should actually return the ``format`` attribute
+  (see plone/Products.CMFPlone#2540)
+  [ale-rt]
 
 
 1.3.0 (2018-09-28)

--- a/plone/stringinterp/tests/moreSubstitutionTests.txt
+++ b/plone/stringinterp/tests/moreSubstitutionTests.txt
@@ -248,7 +248,7 @@ Keywords (alias for subject)
 Format
 
     >>> getAdapter(apage, IStringSubstitution, 'format')()
-    'text/plain'
+    'text/html'
 
 Language
 

--- a/plone/stringinterp/tests/substitutionTests.txt
+++ b/plone/stringinterp/tests/substitutionTests.txt
@@ -198,7 +198,7 @@ Keywords (alias for subject)
 Format
 
     >>> getAdapter(apage, IStringSubstitution, 'format')()
-    'text/plain'
+    'text/html'
 
 Language
 

--- a/plone/stringinterp/tests/wrapperTests.txt
+++ b/plone/stringinterp/tests/wrapperTests.txt
@@ -249,7 +249,7 @@ Keywords (alias for subject)
 Format
 
     >>> getAdapter(apage, IStringSubstitution, 'format')()
-    'text/plain'
+    'text/html'
 
 Language
 


### PR DESCRIPTION
The ``Format`` accessor should actually return the ``format`` attribute (see plone/Products.CMFPlone#2540)